### PR TITLE
Remove deprecated -p option to resize the window

### DIFF
--- a/splitmind/splitter/tmux.py
+++ b/splitmind/splitter/tmux.py
@@ -35,7 +35,7 @@ def tmux_split(*args, target=None, display=None, cmd="/bin/cat -", use_stdin=Fal
     if target is not None:
         args += ["-t", target.id]
     if size is not None:
-        args += ["-p", size[:-1]] if size.endswith("%") else ["-l", size]
+        args += ["-l", size]
     fd = "#{pane_tty}" if not use_stdin else "/proc/#{pane_pid}/fd/0"
     if use_stdin:
         cmd = "(cat)|"+cmd


### PR DESCRIPTION
With the latest version of tmux there was a problem with the -p option causing tmux to return -1 and therefore blocking the splitting.
From the tmux documentation:
> The -l option specifies the size of the new pane in lines (for vertical split) or in columns (for horizontal split); size may be followed by ‘%’ to specify a percentage of the available space.

We can use the `-l` option to do both percentage and line resizing