### PR TITLE
fix: remove deprecated -p size

### DIFF
--- a/splitmind/splitter/tmux.py
+++ b/splitmind/splitter/tmux.py
@@ -35,7 +35,7 @@ def tmux_split(*args, target=None, display=None, cmd="/bin/cat -", use_stdin=Fal
     if target is not None:
         args += ["-t", target.id]
     if size is not None:
-        args += ["-p", size[:-1]] if size.endswith("%") else ["-l", size]
+        args += ["-l", size]
     fd = "#{pane_tty}" if not use_stdin else "/proc/#{pane_pid}/fd/0"
     if use_stdin:
         cmd = "(cat)|"+cmd


### PR DESCRIPTION
There comes errors when using left/right/above/below(self, *args, of=None, display=None, **kwargs)
```shell
size missing
Traceback (most recent call last):
  File "<string>", line 5, in <module>
  File "/home/work/splitmind/splitmind/mind.py", line 37, in right
    self.last = self.splitter.right(*args, of=of or self.last, display=display, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/work/splitmind/splitmind/splitter/tmux.py", line 147, in right
    return self.split("-h",  *args, target=of, display=display, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/work/splitmind/splitmind/splitter/tmux.py", line 137, in split
    split = tmux_split(*args, target=target, display=display, cmd=cmd or self.cmd,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/work/splitmind/splitmind/splitter/tmux.py", line 42, in tmux_split
    res = check_output('tmux split-window -P -d -F'.split(" ")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['tmux', 'split-window', '-P', '-d', '-F', '#{pane_id}:#{pane_tty}', '-h', '-p', '25', '/bin/cat -']' returned non-zero exit status 1.
/home/work/.gdbinit:21: Error in sourced command file:
Error while executing Python code.
``` 
Just fix the deprecated parameter -p size to make it work.